### PR TITLE
Added a more verbose error message if response is 404

### DIFF
--- a/lib/simple_geo/connection.rb
+++ b/lib/simple_geo/connection.rb
@@ -93,7 +93,7 @@ module SimpleGeo
           when 401
             raise Unauthorized
           when 404
-            raise NotFound
+            raise NotFound, "The URL provided is incorrect. #{response_description}"
           when 500
             raise ServerError, "SimpleGeo had an internal error. Please let them know. #{response_description}"
           when 502..503


### PR DESCRIPTION
I spent a little while trying to work out what on earth SimpleGeo::NotFound meant, and thought it was some sort of issue with the gem setup (new machine) or what.

It was probably just me being a muppet, but I'd think this error message should make things a whole lot more obvious.

```
SimpleGeo::NotFound in PlacesController#near

The URL provided is incorrect. (404): Not Found - {"code":404,"message":"Not Found: /1.0/places/,.json"}
```
